### PR TITLE
fix: remove git version pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV TERRAFORM_VERSION=1.7.3
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3006
-RUN apk --no-cache add git=2.43.0-r0 jq=1.7.1-r0
+RUN apk --no-cache add git jq=1.7.1-r0
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 


### PR DESCRIPTION
2.43.0 has been removed from alpine packages